### PR TITLE
feat(exporters): add support for logrecords bytes metrics

### DIFF
--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -63,6 +63,10 @@ func (req *logsRequest) ItemsCount() int {
 	return req.ld.LogRecordCount()
 }
 
+func (req *logsRequest) BytesSize() int {
+	return req.ld.LogRecordBytes()
+}
+
 type logsExporter struct {
 	*baseExporter
 	consumer.Logs
@@ -156,6 +160,6 @@ func newLogsExporterWithObservability(obsrep *ObsReport) requestSender {
 func (lewo *logsExporterWithObservability) send(ctx context.Context, req Request) error {
 	c := lewo.obsrep.StartLogsOp(ctx)
 	err := lewo.nextSender.send(c, req)
-	lewo.obsrep.EndLogsOp(c, req.ItemsCount(), err)
+	lewo.obsrep.EndLogsOp(c, req.ItemsCount(), req.BytesSize(), err)
 	return err
 }

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -63,6 +63,10 @@ func (req *metricsRequest) ItemsCount() int {
 	return req.md.DataPointCount()
 }
 
+func (req *metricsRequest) BytesSize() int {
+	return 0
+}
+
 type metricsExporter struct {
 	*baseExporter
 	consumer.Metrics

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -121,7 +121,7 @@ func (or *ObsReport) createOtelMetrics(cfg ObsReportSettings) error {
 	errors = multierr.Append(errors, err)
 
 	or.sentLogRecordsBytes, err = meter.Int64Histogram(
-		obsmetrics.ExporterMetricPrefix+obsmetrics.SentLogRecordsBytesKey,
+		obsmetrics.ExporterMetricPrefix+"sent_log_records_bytes",
 		metric.WithDescription("Bytes of log records succesfully sent to destination."),
 		metric.WithUnit("By"))
 	errors = multierr.Append(errors, err)

--- a/exporter/exporterhelper/obsexporter_test.go
+++ b/exporter/exporterhelper/obsexporter_test.go
@@ -141,7 +141,7 @@ func TestExportLogsOp(t *testing.T) {
 			ctx := obsrep.StartLogsOp(parentCtx)
 			assert.NotNil(t, ctx)
 
-			obsrep.EndLogsOp(ctx, params[i].items, params[i].err)
+			obsrep.EndLogsOp(ctx, params[i].items, 0, params[i].err)
 		}
 
 		spans := tt.SpanRecorder.Ended()
@@ -223,7 +223,7 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	require.NoError(t, err)
 	ctx := obsrep.StartLogsOp(context.Background())
 	require.NotNil(t, ctx)
-	obsrep.EndLogsOp(ctx, 7, nil)
+	obsrep.EndLogsOp(ctx, 7, 0, nil)
 
 	assert.NoError(t, tt.CheckExporterLogs(7, 0))
 	assert.Error(t, tt.CheckExporterLogs(7, 7))

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -17,6 +17,8 @@ type Request interface {
 	// sent. For example, for OTLP exporter, this value represents the number of spans,
 	// metric data points or log records.
 	ItemsCount() int
+
+	BytesSize() int
 }
 
 // RequestErrorHandler is an optional interface that can be implemented by Request to provide a way handle partial

--- a/exporter/exporterhelper/request_test.go
+++ b/exporter/exporterhelper/request_test.go
@@ -54,6 +54,8 @@ func (r *fakeRequest) ItemsCount() int {
 	return r.items
 }
 
+func (r *fakeRequest) BytesSize() int { return 0 }
+
 func fakeBatchMergeFunc(_ context.Context, r1 Request, r2 Request) (Request, error) {
 	if r1 == nil {
 		return r2, nil

--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -282,6 +282,10 @@ func (mer *mockErrorRequest) ItemsCount() int {
 	return 7
 }
 
+func (mer *mockErrorRequest) BytesSize() int {
+	return 0
+}
+
 func newErrorRequest() Request {
 	return &mockErrorRequest{}
 }
@@ -305,6 +309,8 @@ func (m *mockRequest) Export(ctx context.Context) error {
 	// Respond like gRPC/HTTP, if context is cancelled, return error
 	return ctx.Err()
 }
+
+func (m *mockRequest) BytesSize() int { return 0 }
 
 func (m *mockRequest) OnError(error) Request {
 	return &mockRequest{

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -63,6 +63,8 @@ func (req *tracesRequest) ItemsCount() int {
 	return req.td.SpanCount()
 }
 
+func (req *tracesRequest) BytesSize() int { return 0 }
+
 type traceExporter struct {
 	*baseExporter
 	consumer.Traces

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -70,8 +70,6 @@ replace go.opentelemetry.io/collector/extension => ../extension
 
 replace go.opentelemetry.io/collector/featuregate => ../featuregate
 
-replace go.opentelemetry.io/collector/pdata => ../pdata
-
 replace go.opentelemetry.io/collector/pdata/testdata => ../pdata/testdata
 
 replace go.opentelemetry.io/collector/receiver => ../receiver
@@ -81,3 +79,7 @@ retract v0.76.0 // Depends on retracted pdata v1.0.0-rc10 module
 replace go.opentelemetry.io/collector/config/configretry => ../config/configretry
 
 replace go.opentelemetry.io/collector/config/configtelemetry => ../config/configtelemetry
+
+replace go.opentelemetry.io/collector/pdata => ../pdata
+
+replace go.opentelemetry.io/collector/pdata/plog => ../pdata/plog

--- a/internal/obsreportconfig/obsmetrics/obs_exporter.go
+++ b/internal/obsreportconfig/obsmetrics/obs_exporter.go
@@ -23,6 +23,8 @@ const (
 
 	// SentLogRecordsKey used to track logs sent by exporters.
 	SentLogRecordsKey = "sent_log_records"
+	// SentLogRecordsKey used to track logs sent by exporters.
+	SentLogRecordsBytesKey = "sent_log_records_bytes"
 	// FailedToSendLogRecordsKey used to track logs that failed to be sent by exporters.
 	FailedToSendLogRecordsKey = "send_failed_log_records"
 	// FailedToEnqueueLogRecordsKey used to track logs that failed to be enqueued by exporters.

--- a/internal/obsreportconfig/obsmetrics/obs_receiver.go
+++ b/internal/obsreportconfig/obsmetrics/obs_receiver.go
@@ -23,7 +23,8 @@ const (
 	RefusedMetricPointsKey = "refused_metric_points"
 
 	// AcceptedLogRecordsKey used to identify log records accepted by the Collector.
-	AcceptedLogRecordsKey = "accepted_log_records"
+	AcceptedLogRecordsKey        = "accepted_log_records"
+	AcceptedLogRecordsInBytesKey = "accepted_log_recods_bytes"
 	// RefusedLogRecordsKey used to identify log records refused (ie.: not ingested) by the
 	// Collector.
 	RefusedLogRecordsKey = "refused_log_records"

--- a/pdata/plog/logs.go
+++ b/pdata/plog/logs.go
@@ -55,6 +55,21 @@ func (ms Logs) LogRecordCount() int {
 	return logCount
 }
 
+// LogRecordCount calculates the total number of log records.
+func (ms Logs) LogRecordBytes() int {
+	logBytes := 0
+	rss := ms.ResourceLogs()
+	for i := 0; i < rss.Len(); i++ {
+		rs := rss.At(i)
+		ill := rs.ScopeLogs()
+		for i := 0; i < ill.Len(); i++ {
+			logs := ill.At(i)
+			logBytes += logs.orig.Size()
+		}
+	}
+	return logBytes
+}
+
 // ResourceLogs returns the ResourceLogsSlice associated with this Logs.
 func (ms Logs) ResourceLogs() ResourceLogsSlice {
 	return newResourceLogsSlice(&ms.getOrig().ResourceLogs, internal.GetLogsState(internal.Logs(ms)))


### PR DESCRIPTION
If the upstream PR gets merged (added traces and metrics bytes as well), then a rebase will be required.

Please have a look @kristofgyuracz, I can't ask for a review for some reason.